### PR TITLE
Re sharper check

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,54 @@
+---
+Language: Cpp
+BasedOnStyle: LLVM
+AccessModifierOffset: -4
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignOperands: false
+AlignTrailingComments: false
+AlwaysBreakTemplateDeclarations: Yes
+BraceWrapping: 
+  AfterCaseLabel: true
+  AfterClass: true
+  AfterControlStatement: true
+  AfterEnum: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterStruct: true
+  AfterUnion: true
+  AfterExternBlock: false
+  BeforeCatch: true
+  BeforeElse: true
+  BeforeLambdaBody: true
+  BeforeWhile: true
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBraces: Custom
+BreakConstructorInitializers: AfterColon
+BreakConstructorInitializersBeforeComma: false
+ColumnLimit: 120
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+IncludeCategories: 
+  - Regex: '^<.*'
+    Priority: 1
+  - Regex: '^".*'
+    Priority: 2
+  - Regex: '.*'
+    Priority: 3
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseBlocks: true
+IndentWidth: 4
+InsertNewlineAtEOF: true
+MacroBlockBegin: ''
+MacroBlockEnd: ''
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: All
+PointerAlignment: Left
+SpaceInEmptyParentheses: false
+SpacesInAngles: false
+SpacesInConditionalStatement: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+TabWidth: 4
+...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,37 @@
+---
+Checks: >
+  *,
+  -abseil-*,
+  -altera-*,
+  -fuchsia-*,
+  -google-*,
+  -llvm-*,
+  -zircon-*,
+  performance-*,
+  readability-*,
+  modernize-*,
+  cppcoreguidelines-*,
+  -modernize-use-trailing-return-type,
+  -readability-magic-numbers,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -readability-identifier-length,
+  -modernize-use-nodiscard,
+  -cppcoreguidelines-avoid-do-while,
+  -readability-convert-member-functions-to-static,
+  -modernize-use-auto
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+FormatStyle: file
+CheckOptions:
+  - key: readability-function-cognitive-complexity.Threshold
+    value: '25'
+  - key: readability-function-size.LineThreshold
+    value: '80'
+  - key: cppcoreguidelines-pro-bounds-constant-array-index.GslHeader
+    value: ''
+  - key: modernize-loop-convert.MaxCopySize
+    value: '16'
+  - key: modernize-loop-convert.MinConfidence
+    value: reasonable
+  - key: modernize-use-nullptr.NullMacros
+    value: 'NULL'

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -5,7 +5,10 @@
       "Bash(ninja:*)",
       "WebFetch(domain:github.com)",
       "WebFetch(domain:cmake.org)",
-      "WebFetch(domain:code.visualstudio.com)"
+      "WebFetch(domain:code.visualstudio.com)",
+      "WebFetch(domain:docs.anthropic.com)",
+      "WebFetch(domain:www.jetbrains.com)",
+      "mcp__ide__getDiagnostics"
     ],
     "deny": []
   },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,16 @@
 {
     "cmake.configureOnOpen": true,
     "cmake.useCMakePresets": "always",
-    "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools",
+    
+    // clangd configuration
+    "C_Cpp.intelliSenseEngine": "disabled",
+    "clangd.path": "clangd.exe",
+    "clangd.arguments": [
+        "--compile-commands-dir=out/build/x64-debug",
+        "--clang-tidy",
+        "--header-insertion=iwyu",
+        "--completion-style=detailed"
+    ],
 
     "markdownlint.config": {
         "MD022": false,

--- a/CppUtilities.cpp
+++ b/CppUtilities.cpp
@@ -5,8 +5,19 @@
 
 using namespace std;
 
+// Test function to trigger clang-tidy warnings
+void test_function() {
+    int magic_number = 42;  // clang-tidy: magic number
+    int* ptr = NULL;        // clang-tidy: use nullptr
+    
+    for(int i=0;i<10;++i) { // clang-tidy: spacing
+        cout << magic_number << endl;
+    }
+}
+
 int main()
 {
 	cout << "Hello CMake." << endl;
+	test_function();
 	return 0;
 }

--- a/Folder.DotSettings
+++ b/Folder.DotSettings
@@ -1,0 +1,9 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppClangTidyReadabilityAvoidReturnWithVoidValue/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppCStyleCast/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppInconsistentNaming/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppMemberFunctionMayBeConst/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppMemberFunctionMayBeStatic/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppParameterNeverUsed/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppRedundantTemplateArguments/@EntryIndexedValue">SUGGESTION</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CppTemplateParameterNeverUsed/@EntryIndexedValue">WARNING</s:String></wpf:ResourceDictionary>


### PR DESCRIPTION
This pull request introduces several changes to improve C++ code formatting, static analysis, and IDE configurations. The most important changes include the addition of `.clang-format` and `.clang-tidy` configuration files, updates to IDE settings for `clangd`, and new diagnostic rules for code inspections.

### Code formatting and static analysis:

* Added `.clang-format` file with detailed rules for C++ code formatting, such as brace wrapping, indentation, and line width limits, based on the LLVM style.
* Added `.clang-tidy` file to enable and configure specific static analysis checks, including performance, readability, and modern C++ guidelines, while disabling certain checks like magic numbers and trailing return types.

### IDE configuration:

* Updated `.vscode/settings.json` to configure `clangd` as the IntelliSense engine with specific arguments for compile commands, clang-tidy integration, and detailed completion styles.
* Modified `.claude/settings.local.json` to allow web fetches from additional domains (e.g., `docs.anthropic.com` and `www.jetbrains.com`) and added a new diagnostic entry.

### Code inspection rules:

* Added `Folder.DotSettings` file to define inspection severities for various clang-tidy checks, such as inconsistent naming, unused parameters, and redundant template arguments.

### Test code:

* Introduced a test function in `CppUtilities.cpp` to demonstrate clang-tidy warnings, including the use of magic numbers, `NULL` instead of `nullptr`, and spacing issues.